### PR TITLE
Use newer `yarn` flags

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
           corepack enable
       - name: Install node modules
         run: |
-          yarn install --frozen-lockfile
+          yarn install --immutable --immutable-cache --check-cache
       - name: Lint
         run: |
           yarn lint


### PR DESCRIPTION
## Motivation

`--frozen-lockfile` is deprecated. The successors are `--immutable`, `--immutable-cache` and `--check-cache`, which make the command error when the lockfile was to be modified, when the cache was to be modified, and if the checksums aren't up to date, respectively.


## Type of change

<!-- Please tick the right option -->

- [x] Housekeeping
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions to reproduce if necessary. Please also list any relevant details for your test configuration -->

- [ ] Jest Unit Test
- [ ] Ran on iOS Simulator
- [ ] Ran on iOS physical device
- [ ] Ran on Android emulator
- [ ] Ran on Android physical device
- [x] N/A
