### PR TITLE
Avoid redefining components during rendering

### DIFF
--- a/src/components/CorporationDetailsScreen.tsx
+++ b/src/components/CorporationDetailsScreen.tsx
@@ -1,5 +1,5 @@
 import {makeStyles} from '@rneui/themed';
-import React, {memo, useEffect} from 'react';
+import React, {memo, useCallback, useEffect} from 'react';
 
 import {CorporationDetailsScreenProps} from '../types/screens';
 import {CorporationDetails} from './details/Corporation';
@@ -13,10 +13,15 @@ export const CorporationDetailsScreen = memo(
     const styles = useStyles();
     const corporation = route.params.corporation;
 
+    const RequestChangeForCorporationButton = useCallback(
+      () => <RequestChangeButton name={corporation.shortName} />,
+      [corporation],
+    );
+
     useEffect(() => {
       navigation.setOptions({
         title: corporation.shortName,
-        headerRight: () => <RequestChangeButton name={corporation.shortName} />,
+        headerRight: RequestChangeForCorporationButton,
       });
     });
 

--- a/src/components/FavouriteButton.tsx
+++ b/src/components/FavouriteButton.tsx
@@ -1,0 +1,64 @@
+import {Button, makeStyles, useTheme} from '@rneui/themed';
+import React, {memo, useContext, useEffect, useState} from 'react';
+import {useTranslation} from 'react-i18next';
+
+import constants from '../constants';
+import log from '../log';
+import {ToggleFavouriteAction} from '../types/state';
+import {StateContext} from './contexts/GlobalStateContext';
+
+export interface FavouriteButtonProps {
+  itemId: string;
+  toggleAction: (id: string) => ToggleFavouriteAction;
+  postDispatch?: () => void;
+}
+
+/**
+ * A button to toggle an item as a favourite
+ *
+ * @param itemId the ID of the item
+ * @param toggleAction the action to dispatch to toggle the item as a favourite
+ * @param postDispatch function to call after dispatching
+ */
+export const FavouriteButton = memo(
+  ({itemId, toggleAction, postDispatch}: FavouriteButtonProps) => {
+    const {globalState, dispatch} = useContext(StateContext);
+    const styles = useStyles();
+    const {theme} = useTheme();
+    const {t} = useTranslation();
+
+    const [isFavourite, setIsFavourite] = useState(
+      globalState.favourites.corporation.has(itemId),
+    );
+
+    useEffect(() => {
+      log.debug('State changed: FavouriteButton');
+      setIsFavourite(globalState.favourites.corporation.has(itemId));
+    }, [globalState, itemId]);
+
+    return (
+      <Button
+        buttonStyle={styles.favouriteButton}
+        title={t('BUTTON_FAVOURITE') || ''}
+        icon={{
+          name: isFavourite
+            ? constants.icons.explore.favourite
+            : constants.icons.explore.nonFavourite,
+          color: theme.colors.iconOnPrimaryColourBackgroundColour,
+        }}
+        onPress={() => {
+          dispatch(toggleAction(itemId));
+          if (postDispatch) {
+            postDispatch();
+          }
+        }}
+      />
+    );
+  },
+);
+
+const useStyles = makeStyles(() => ({
+  favouriteButton: {
+    height: '100%',
+  },
+}));

--- a/src/components/explore/ExploreCities.tsx
+++ b/src/components/explore/ExploreCities.tsx
@@ -22,7 +22,7 @@ export const ExploreCitiesScreen = ({}: ScreenProps) => {
         component={CityListScreen}
         options={{
           title: t('SCREEN_CITIES'),
-          headerLeft: () => <ToggleDrawerButton />,
+          headerLeft: ToggleDrawerButton,
         }}
         initialParams={{
           testID: 'Screen:ExploreCities',

--- a/src/components/explore/ExploreCountries.tsx
+++ b/src/components/explore/ExploreCountries.tsx
@@ -23,7 +23,7 @@ export const ExploreCountriesScreen = ({}: ScreenProps) => {
         component={CountryListScreen}
         options={{
           title: t('SCREEN_COUNTRIES'),
-          headerLeft: () => <ToggleDrawerButton />,
+          headerLeft: ToggleDrawerButton,
         }}
       />
       <Stack.Screen

--- a/src/components/explore/ExploreNearby.tsx
+++ b/src/components/explore/ExploreNearby.tsx
@@ -22,6 +22,7 @@ import {SortButton} from './SortButton';
 const Stack = createNativeStackNavigator<StackScreenParamsList>();
 
 const screenName: ExploreScreen = 'Closest';
+const NamedSortButton = () => <SortButton screenName={screenName} />;
 
 const fetchNearbyAddresses = (
   model: CouleurbummelModel,
@@ -92,8 +93,8 @@ export const ExploreNearbyScreen = ({}: ScreenProps) => {
         component={NearbyScreen}
         options={{
           title: t('SCREEN_NEARBY'),
-          headerLeft: () => <ToggleDrawerButton />,
-          headerRight: () => <SortButton screenName={screenName} />,
+          headerLeft: ToggleDrawerButton,
+          headerRight: NamedSortButton,
         }}
       />
       <Stack.Screen

--- a/src/components/explore/ExploreOrganisations.tsx
+++ b/src/components/explore/ExploreOrganisations.tsx
@@ -23,6 +23,7 @@ import {SortButton} from './SortButton';
 const Stack = createNativeStackNavigator<StackScreenParamsList>();
 
 const screenName: ExploreScreen = 'Organisations';
+const NamedSortButton = () => <SortButton screenName={screenName} />;
 
 /**
  * The root screen in the Organisations section
@@ -37,7 +38,7 @@ export const ExploreOrganisationsScreen = ({}: ScreenProps) => {
         component={OrganisationList}
         options={{
           title: t('SCREEN_ORGANISATIONS'),
-          headerLeft: () => <ToggleDrawerButton />,
+          headerLeft: ToggleDrawerButton,
         }}
       />
       <Stack.Screen
@@ -45,7 +46,7 @@ export const ExploreOrganisationsScreen = ({}: ScreenProps) => {
         component={CorporationListScreen}
         options={{
           title: t('SCREEN_CORPORATION_LIST'),
-          headerRight: () => <SortButton screenName={screenName} />,
+          headerRight: NamedSortButton,
         }}
       />
       <Stack.Screen

--- a/src/components/navigation/Navigation.tsx
+++ b/src/components/navigation/Navigation.tsx
@@ -143,7 +143,7 @@ export const Navigation = () => {
           options={{
             headerShown: true,
             title: t('SCREEN_SETTINGS'),
-            headerLeft: () => <ToggleDrawerButton />,
+            headerLeft: ToggleDrawerButton,
           }}
           name="Settings"
           component={SettingsScreen}

--- a/src/components/navigation/ToggleDrawerButton.tsx
+++ b/src/components/navigation/ToggleDrawerButton.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import constants from '../../constants';
 
 /**
- * The button to toggle the drawer
+ * The button component to toggle the drawer
  */
 export const ToggleDrawerButton = () => {
   const {theme} = useTheme();
@@ -20,6 +20,7 @@ export const ToggleDrawerButton = () => {
     />
   );
 };
+
 const useStyles = makeStyles(() => ({
   menuButton: {
     backgroundColor: 'transparent',

--- a/src/components/search/SearchColours.tsx
+++ b/src/components/search/SearchColours.tsx
@@ -35,6 +35,7 @@ import {ToggleDrawerButton} from '../navigation/ToggleDrawerButton';
 import {ColoursQuery, searchColours} from './helpers';
 
 const screenName: DrawerScreenName = 'SearchColours';
+const NamedSortButton = () => <SortButton screenName={screenName} />;
 
 const Stack = createNativeStackNavigator<StackScreenParamsList>();
 
@@ -48,8 +49,8 @@ export const SearchColoursScreen = ({}: ColoursSearchScreenProps) => {
         component={SearchColours}
         options={{
           title: t('SCREEN_SEARCH_COLOURS'),
-          headerLeft: () => <ToggleDrawerButton />,
-          headerRight: () => <SortButton screenName={screenName} />,
+          headerLeft: ToggleDrawerButton,
+          headerRight: NamedSortButton,
         }}
       />
       <Stack.Screen

--- a/src/components/search/SearchName.tsx
+++ b/src/components/search/SearchName.tsx
@@ -16,6 +16,7 @@ import {ToggleDrawerButton} from '../navigation/ToggleDrawerButton';
 const Stack = createNativeStackNavigator<StackScreenParamsList>();
 
 const screenName = 'SearchName';
+const NamedSortButton = () => <SortButton screenName={screenName} />;
 
 /**
  * The root screen in the search by name section
@@ -30,8 +31,8 @@ export const SearchNameScreen = ({}: ScreenProps) => {
         component={SearchScreen}
         options={{
           title: t('SCREEN_SEARCH_NAME'),
-          headerLeft: () => <ToggleDrawerButton />,
-          headerRight: () => <SortButton screenName={screenName} />,
+          headerLeft: ToggleDrawerButton,
+          headerRight: NamedSortButton,
         }}
       />
       <Stack.Screen

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -59,7 +59,7 @@ interface Constants {
     sort: {
       sortButton: string;
       selectedSortOption: string;
-      sortbyName: string;
+      sortByName: string;
       sortByDistance: string;
     };
     favourites: {
@@ -209,7 +209,7 @@ const constants: Readonly<Constants> = Object.freeze({
     sort: {
       sortButton: 'sort',
       selectedSortOption: 'check',
-      sortbyName: 'sort-alphabetical-ascending',
+      sortByName: 'sort-alphabetical-ascending',
       sortByDistance: 'map-marker',
     },
     favourites: {


### PR DESCRIPTION
## Motivation

This change avoids the definition of new components in `render()` calls, but instead moved them out into their own components or memoises the definitions.

If we didn't do that, React would recreate the state of each of these components on every call, which is a performance issue and could lead to inconsistencies if the components have a state that should be preserved.

## Type of change

<!-- Please tick the right option -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions to reproduce if necessary. Please also list any relevant details for your test configuration -->

- [x] Jest Unit Test
- [x] Ran on iOS Simulator
- [x] Ran on iOS physical device
- [x] Ran on Android emulator
- [ ] Ran on Android physical device

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [x] New and existing unit tests pass locally with my changes
- [ ] ~Any dependent changes have been merged and published in downstream modules~

## Additional context

<!-- Add any other context or screenshots here. -->
