### PR TITLE
Use Play Integrity instead of SafetyNet

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -174,7 +174,7 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:31.1.1')
 
     // Add the dependency for the App Check library
-    implementation 'com.google.firebase:firebase-appcheck-safetynet'
+    implementation 'com.google.firebase:firebase-appcheck-playintegrity'
 
     debugImplementation("com.facebook.flipper:flipper:${FLIPPER_VERSION}")
 


### PR DESCRIPTION
## Motivation

SafetyNet is deprecated and RNFirebase now finally supports Play Integrity, so we can switch to that as the app attestation provider.

Relates to: #80

## Type of change

<!-- Please tick the right option -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Housekeeping (non-code change)

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. Provide instructions to reproduce if necessary. Please also list any relevant details for your test configuration -->

- [ ] Jest Unit Test
- [ ] Ran on iOS Simulator
- [ ] Ran on iOS physical device
- [x] Ran on Android emulator
- [x] Ran on Android physical device

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

<!-- Add any other context or screenshots here. -->
